### PR TITLE
Main

### DIFF
--- a/lua/MyNvim/plugins-config/lspconfig.lua
+++ b/lua/MyNvim/plugins-config/lspconfig.lua
@@ -6,6 +6,7 @@ return function(_, _)
   -- lspconfig.pyright.setup {}
   lspconfig.pylsp.setup {}
   lspconfig.clangd.setup {}
+  lspconfig.ts_ls.setup {}
   lspconfig.lua_ls.setup {
     settings = {
       Lua = {
@@ -30,7 +31,6 @@ return function(_, _)
       },
     },
   }
-  lspconfig.tsserver.setup {}
   lspconfig.rust_analyzer.setup {
     -- Server-specific settings. See `:help lspconfig-setup`
     settings = {

--- a/lua/plugins-install/neorg.lua
+++ b/lua/plugins-install/neorg.lua
@@ -3,7 +3,7 @@ local M = {
   "nvim-neorg/neorg",
   build = ":Neorg sync-parsers",
   dependencies = { "nvim-lua/plenary.nvim" },
-  lazy = false,
+  lazy = true,
   config = function()
     if status then
       require("neorg").setup(load)


### PR DESCRIPTION
- Changed the typescript language server name in the `lspconfig` plugin from `tsserver` to `ts_ls`, check this [PR](https://github.com/neovim/nvim-lspconfig/pull/3232) for context.
- The `Neorg` plugin now is lazily loaded.