### PR TITLE
fix: rool back to neorg `8.0.0` to make file/url links work properly

### DIFF
--- a/lua/plugins-install/neorg.lua
+++ b/lua/plugins-install/neorg.lua
@@ -3,6 +3,7 @@ local M = {
   "nvim-neorg/neorg",
   build = ":Neorg sync-parsers",
   dependencies = { "nvim-lua/plenary.nvim" },
+  version = "8.0.0";
   lazy = true,
   config = function()
     if status then


### PR DESCRIPTION
- Rolled back to Neorg `8.0.0` to temporarily fix this [issue](https://github.com/nvim-neorg/neorg/issues/1544#issuecomment-2258588375)